### PR TITLE
Skip unoccupied tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,9 +62,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "libloading"
@@ -123,9 +123,9 @@ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
 dependencies = [
  "unicode-ident",
 ]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Currently the following commands can be used with flow.
 
 | Command | Arguments | Description | Example |
 | --- | --- | --- | --- |
-| `cycle-tags` | Direction: `next` or `previous`. Number of available tags: `int`, defaults to `9` if omitted. | Move focused tag to the next or previous tag. | `flow cycle-tags next 6` |
+| `cycle-tags` | Direction: `next` or `previous`. Number of available tags: `int`, defaults to `9` if omitted. | Move focused tag to the next or previous tag. Optionally the user can append the flag `-o` or `--occupied` to only cycle through occupied tags. | `flow cycle-tags next 6` |
 | `toggle-tags` | Tags to focus. | Focus tags or toggle previous tags if already focused. | `flow toggle-tags 64` |
 | `focus-urgent-tags` | None. | Focus urgent tags on an output. | `flow focus-urgent-tags` |
 | `focus-set-view-tags` | Tags to set and focus. | Set tags for a view and then focus the tags | `flow focus-set-view-tags 16` |

--- a/src/client.rs
+++ b/src/client.rs
@@ -12,7 +12,7 @@ use crate::protocols::river_protocols::{
     zriver_command_callback_v1::ZriverCommandCallbackV1,
     zriver_control_v1::ZriverControlV1,
     zriver_output_status_v1::{
-        Event::{FocusedTags, UrgentTags},
+        Event::{FocusedTags, UrgentTags, ViewTags},
         ZriverOutputStatusV1,
     },
     zriver_seat_status_v1::{self, ZriverSeatStatusV1},
@@ -32,6 +32,7 @@ pub struct Flow {
     pub focused_tags: Option<u32>,
     pub urgent: HashMap<OutputName, u32>,
     pub control: Option<ZriverControlV1>,
+    pub occupied_tags: Vec<u8>,
 }
 
 impl Flow {
@@ -46,6 +47,7 @@ impl Flow {
             focused_tags: None,
             urgent: HashMap::new(),
             control: None,
+            occupied_tags: vec![],
         }
     }
 
@@ -83,13 +85,118 @@ impl Flow {
         self.focused_tags == Some(*to_tags)
     }
 
-    pub fn cycle_tags(&self, direction: &str, n_tags: &u8, queue_handle: &QueueHandle<Self>) {
-        let last_tag: u32 = 1 << (n_tags - 1);
-        let mut new_tags = 0;
-        let mut tags = self.focused_tags.unwrap_or_default();
+    /// Find the next occupied tag in the direction
+    fn find_next_occupied(
+        &self,
+        occupied_tags: &[u8],
+        direction: &str,
+        tag_index: u8,
+    ) -> Option<u8> {
+        let mut result: Option<u8> = None;
+
+        // Go over each tag in the occupied tags
+        for &occupied_tag_index in occupied_tags.iter() {
+            // If we cycle next the tag index should be greater than the one we're looking up.
+            // Otherwise it should be smaller.
+            let condition = if direction == "next" {
+                occupied_tag_index > tag_index
+            } else {
+                occupied_tag_index < tag_index
+            };
+
+            // Then find the closest occupied tag according to direction by using min/max function on each tag and replace the value.
+            // This could be None, which is fine, and will be unhandled with an unwrap to a default tag position.
+            if condition {
+                result = Some(result.map_or(occupied_tag_index, |next_occupied| {
+                    if direction == "next" {
+                        u8::min(next_occupied, occupied_tag_index)
+                    } else {
+                        u8::max(next_occupied, occupied_tag_index)
+                    }
+                }));
+            }
+        }
+
+        result
+    }
+
+    /// Find the indices of set bits
+    fn find_set_bits_positions(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+
+        // Iterate over 4-byte chunks of the occupied tags
+        for chunk in self.occupied_tags.chunks(4) {
+            // Then iterate over bytes in the current chunk, along with their indices
+            for (byte_index, &byte) in chunk.iter().enumerate() {
+                // And iterate over bits in the current byte
+                for bit_index in 0..8 {
+                    // Check if the bit at bit_index is set = occupied tag
+                    if (byte & (1 << bit_index)) != 0 {
+                        // If set, calculate the overall bit index and push it to the result vector
+                        result.push((byte_index * 8 + bit_index) as u8);
+                    }
+                }
+            }
+        }
+
+        result
+    }
+
+    /// Cycle the tagmask in either next or previous direction
+    pub fn cycle_tags(
+        &self,
+        direction: &str,
+        n_tags: &u8,
+        skip_unoccupied: bool,
+        queue_handle: &QueueHandle<Self>,
+    ) {
+        let tags: u32 = self.focused_tags.unwrap_or_default();
+        let mut new_tags: u32 = tags;
+
+        let occupied_tags = self.find_set_bits_positions();
 
         match direction {
+            // Only skip unoccupied on user flag and if there are more than one occupied tag
+            "next" | "previous" if skip_unoccupied && occupied_tags.len() > 1 => {
+                let mut old_bits: Vec<u8> = Vec::new();
+                let mut new_bits: Vec<u8> = Vec::new();
+
+                let wrap_around = if direction == "next" { 0 } else { n_tags - 1 };
+
+                for tag_index in (0..*n_tags).filter(|&i| (tags >> i) & 1 == 1) {
+                    // Find the next occupied position
+                    let mut next_occupied = self
+                        .find_next_occupied(&occupied_tags, direction, tag_index)
+                        .unwrap_or(wrap_around);
+
+                    // Handle the cases where we hit the wrap_around and need to go again to find the next occupied
+                    if next_occupied == wrap_around && !occupied_tags.contains(&wrap_around) {
+                        next_occupied = self
+                            .find_next_occupied(&occupied_tags, direction, next_occupied)
+                            .unwrap_or(wrap_around);
+                    }
+
+                    // Set the next occupied tag
+                    new_tags |= 1 << next_occupied;
+
+                    // Add each old and new bit to vector
+                    old_bits.push(tag_index);
+                    new_bits.push(next_occupied);
+                }
+
+                // Go over the old bits and unset those that are no longer part of the tagmask
+                for bit in old_bits {
+                    if !new_bits.contains(&bit) {
+                        new_tags &= !(1 << bit);
+                    }
+                }
+            }
+
             "next" => {
+                let mut tags = tags;
+                new_tags = 0;
+                let last_tag: u32 = 1 << (n_tags - 1);
+
                 if tags & last_tag != 0 {
                     tags ^= last_tag;
                     new_tags = 1;
@@ -98,6 +205,10 @@ impl Flow {
                 new_tags |= tags << 1;
             }
             "previous" => {
+                let mut tags = tags;
+                new_tags = 0;
+                let last_tag: u32 = 1 << (n_tags - 1);
+
                 if (tags & 1) != 0 {
                     tags ^= 1;
                     new_tags = last_tag;
@@ -169,6 +280,9 @@ impl Dispatch<ZriverOutputStatusV1, (WlOutput, String)> for Flow {
         _: &QueueHandle<Self>,
     ) {
         match event {
+            ViewTags { tags } => {
+                state.occupied_tags = tags;
+            }
             FocusedTags { tags } => {
                 // Ignore the tags that are not on the focused output
                 if &output.0

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,9 +68,18 @@ fn main() {
     event_queue.roundtrip(&mut flow).expect(ROUNDTRIP_EXPECT);
 
     match command {
-        Ok(Arguments::CycleTags { direction, n_tags }) => {
+        Ok(Arguments::CycleTags {
+            direction,
+            n_tags,
+            skip_unoccupied,
+        }) => {
             // If there are no n_tags assigned, or if unwrap fails, we assume default of 9
-            flow.cycle_tags(&direction, &n_tags.unwrap_or(9), &queue_handle);
+            flow.cycle_tags(
+                &direction,
+                &n_tags.unwrap_or(9),
+                skip_unoccupied,
+                &queue_handle,
+            );
         }
         Ok(Arguments::ToggleTags { to_tags }) => {
             if flow.toggle_tags(&to_tags) {

--- a/src/options.rs
+++ b/src/options.rs
@@ -5,6 +5,7 @@ USAGE:
   flow [COMMAND] [ARGS]
 FLAGS:
   -h, --help            Prints help information
+  -o, --occupied        This flag can be appended to the cycle-tags command to only cycle through occupied tags.
 COMMAND:
   cycle-tags            Takes two arguments. Direction (next or previous) and an optional number of available tags (Default: 9).
   toggle-tags           Toggle previous tags if selected tags already focused.
@@ -20,6 +21,7 @@ pub enum Arguments {
     CycleTags {
         direction: String,
         n_tags: Option<u8>,
+        skip_unoccupied: bool,
     },
     ToggleTags {
         to_tags: u32,
@@ -37,6 +39,7 @@ pub fn parse_args() -> Result<Arguments, Box<dyn std::error::Error>> {
         Some("cycle-tags") => Ok(Arguments::CycleTags {
             direction: pargs.free_from_str()?,
             n_tags: pargs.opt_free_from_str()?,
+            skip_unoccupied: pargs.contains(["-o", "--occupied"]),
         }),
         Some("toggle-tags") => Ok(Arguments::ToggleTags {
             to_tags: pargs.free_from_str()?,


### PR DESCRIPTION
This adds the possbility to skip unoccupied tags when using `cycle-tags` as requested in #1. Append the flag `-o` or `--occupied` to the command in order move the tagmask over only the occupied tags.

Note to self: update readme and help.